### PR TITLE
fix(dockerfile): pin roadrunner version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN npm install
 # RUN npm run production
 
 # install roadrunner
-COPY --from=spiralscout/roadrunner:latest /usr/bin/rr /usr/bin/rr
+COPY --from=spiralscout/roadrunner:2023.3.2 /usr/bin/rr /usr/bin/rr
 
 # configure roadrunner
 RUN php artisan octane:install --server=roadrunner


### PR DESCRIPTION
Should solve errors

```
WARN  Unable to determine the current RoadRunner binary version. Please report this issue: https://github.com/laravel/octane/issues/new.
 
ERROR  please, update your configuration version from version: '2.7' to version: '3', see changes here: https://roadrunner.dev/docs/plugins-config/current#v30-configuration
```